### PR TITLE
add meters as a unit option for distance and pace conversions

### DIFF
--- a/src/app/components/common-distances.tsx
+++ b/src/app/components/common-distances.tsx
@@ -12,11 +12,15 @@ export default function CommonDistances({ setDistance, currentUnit, setSelectedV
   function handleSelection(selectionOption: string, currentUnit: string) {
     const values = selectionOption.split(" ");
 
-    const distanceValue = values[0];
-    if (currentUnit == "km") {
-      setDistance(parseFloat(distanceValue));
-    } else {
-      setDistance(parseFloat(distanceValue) * 0.621371);
+    const distanceValue = parseFloat(values[0]);
+
+    // Common distances are in km, convert to current unit
+    if (currentUnit === "km") {
+      setDistance(distanceValue);
+    } else if (currentUnit === "mi") {
+      setDistance(distanceValue * 0.621371);
+    } else if (currentUnit === "m") {
+      setDistance(distanceValue * 1000);
     }
     setSelectedValue(selectionOption);
   }

--- a/src/app/components/distance.tsx
+++ b/src/app/components/distance.tsx
@@ -33,7 +33,25 @@ export default function Distance({ distance, setDistance, setDistanceUnit, dista
 
   const handleUnitChange = (newUnit: string) => {
     if (newUnit !== distanceUnit) {
-      const convertedDistance = newUnit === 'km' ? distance * 1.60934 : distance / 1.60934;
+      let convertedDistance = distance;
+
+      // Convert current distance to meters first
+      let distanceInMeters = distance;
+      if (distanceUnit === 'mi') {
+        distanceInMeters = distance * 1609.34;
+      } else if (distanceUnit === 'km') {
+        distanceInMeters = distance * 1000;
+      }
+
+      // Convert from meters to target unit
+      if (newUnit === 'mi') {
+        convertedDistance = distanceInMeters / 1609.34;
+      } else if (newUnit === 'km') {
+        convertedDistance = distanceInMeters / 1000;
+      } else {
+        convertedDistance = distanceInMeters;
+      }
+
       setDistance(Number(convertedDistance.toFixed(2)));
       setDistanceUnit(newUnit);
     }
@@ -53,6 +71,9 @@ export default function Distance({ distance, setDistance, setDistanceUnit, dista
           <p> / </p>
           <p className={`${distanceUnit === "km" ? "font-bold" : ""} cursor-pointer`}
             onClick={() => handleUnitChange("km")}> km </p>
+          <p> / </p>
+          <p className={`${distanceUnit === "m" ? "font-bold" : ""} cursor-pointer`}
+            onClick={() => handleUnitChange("m")}> m </p>
         </span>
         <CommonDistances setDistance={setDistance} currentUnit={distanceUnit} setSelectedValue={setSelectedValue} selectedValue={selectedValue} />
       </div>

--- a/src/app/components/result.tsx
+++ b/src/app/components/result.tsx
@@ -34,6 +34,15 @@ export default function Result({
           }}
         >
           km
+        </span>{" "}
+        /{" "}
+        <span
+          className={`${resultUnit == "m" ? "font-bold" : ""} cursor-pointer`}
+          onClick={() => {
+            setResultUnit("m");
+          }}
+        >
+          m
         </span>
         ):
       </Text>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -32,14 +32,20 @@ function calculatePace(totalSeconds: number, distanceUnit: string, distance: num
     return "Please enter a distance greater than 0.";
   }
 
+  // Convert distance to miles for calculation
   if (distanceUnit === "km") {
     distance = distance * 0.621371;
+  } else if (distanceUnit === "m") {
+    distance = distance / 1609.34;
   }
 
   let pace = totalSeconds / distance;
 
+  // Convert pace to result unit
   if (resultUnit === "km") {
     pace = pace * 0.621371;
+  } else if (resultUnit === "m") {
+    pace = pace / 1609.34;
   }
 
   let paceMinutes = Math.floor(pace / 60);
@@ -48,7 +54,15 @@ function calculatePace(totalSeconds: number, distanceUnit: string, distance: num
 }
 
 function calculateSplitPace(totalSeconds: number, distanceUnit: string, distance: number, splitDistance: number): string {
-  const totalDistanceInMeters = distanceUnit === "km" ? distance * 1000 : distance * 1609.34;
+  let totalDistanceInMeters: number;
+  if (distanceUnit === "km") {
+    totalDistanceInMeters = distance * 1000;
+  } else if (distanceUnit === "m") {
+    totalDistanceInMeters = distance;
+  } else {
+    totalDistanceInMeters = distance * 1609.34;
+  }
+
   const splitTime = (totalSeconds / totalDistanceInMeters) * splitDistance;
   const splitMinutes = Math.floor(splitTime / 60);
   const splitSeconds = splitTime % 60;


### PR DESCRIPTION
- Add meters (m) as a selectable unit alongside miles and km
- Update distance component with robust unit conversion logic
- Update common distances to handle meters conversion (1 km = 1000 m)
- Update pace calculation to support meters input and output
- Update split pace calculation to handle meters natively
- Add meters option to result unit selector